### PR TITLE
Fix spaces

### DIFF
--- a/PC98_Leaf_Shizuku.js
+++ b/PC98_Leaf_Shizuku.js
@@ -38,7 +38,7 @@ function firstCharHandler(args) {
         if (enable === true) {
             enable = false;
             console.warn("onEnter");
-            const s = enc.readString(address).trim();
+            const s = enc.readString(address).trim().replace(/ /g, '');
             if (s.length !== 0) {
                 mainHandler(s);
             }


### PR DESCRIPTION
Remove spaces that break wrapping words.
Ex: 意 味もなく => 意味もなく