### PR TITLE
Add script for Danganronpa Series (Steam)

### DIFF
--- a/PC_Steam_Danganronpa_2_Goodbye_Despair.js
+++ b/PC_Steam_Danganronpa_2_Goodbye_Despair.js
@@ -1,0 +1,36 @@
+// ==UserScript==
+// @name         Danganronpa 2: Goodbye Despair
+// @version      0.1
+// @author       [blacktide082]
+// @description  Steam
+// * Spike Chunsoft
+//
+// https://store.steampowered.com/app/413420/Danganronpa_2_Goodbye_Despair/
+// ==/UserScript==
+
+const __e = Process.enumerateModules()[0];
+const handler = trans.send(s => s, '200++'); // join lines
+
+(function () {
+    const dialogSig = '66 ?? ?? C1 ?? ?? 03 ?? 66 ?? ?? ?? ???????? 80 ?? ?? 75 ?? 8A ?? ?? 80';
+    const results = Memory.scanSync(__e.base, __e.size, dialogSig);
+    if (results.length === 0) {
+        console.error('[DialoguePattern] Hook not found!');
+        return;
+    }
+
+    let text = '';
+    const address = results[0].address;
+    console.log('[DialoguePattern] Found hook', address);
+
+    Interceptor.attach(address, function (args) {
+        const value = this.context.esi.readUtf16String()
+            .replace(/<CLT.*?>/g, '')
+            .replaceAll('\n', '')
+            .trim();
+        if (!text.endsWith(value)) {
+            text = value;
+            handler(text);
+        }
+    });
+})();

--- a/PC_Steam_Danganronpa_Another_Episode_Ultra_Despair_Girls.js
+++ b/PC_Steam_Danganronpa_Another_Episode_Ultra_Despair_Girls.js
@@ -1,0 +1,36 @@
+// ==UserScript==
+// @name         Danganronpa Another Episode: Ultra Despair Girls
+// @version      0.1
+// @author       [blacktide082]
+// @description  Steam
+// * Spike Chunsoft
+//
+// https://store.steampowered.com/app/555950/Danganronpa_Another_Episode_Ultra_Despair_Girls/
+// ==/UserScript==
+
+const __e = Process.enumerateModules()[0];
+const handler = trans.send(s => s, '100+');
+
+(function () {
+    const dialogSig = '66 ?? ?? ?? ?? 8B ?? ???????? 01 ?? ???????? 0F?? ?? ?? ?? EB';
+    const results = Memory.scanSync(__e.base, __e.size, dialogSig);
+    if (results.length === 0) {
+        console.error('[DialoguePattern] Hook not found!');
+        return;
+    }
+
+    const address = results[0].address;
+    console.log('[DialoguePattern] Found hook', address);
+
+    let timeout = 0;
+    let previous = ' ';
+    Interceptor.attach(address, function (args) {
+        const text = args[3].readUtf16String()
+            .replace(/#[Rl][0-9]+[#\.]{0,2}/g, '')
+            .replace(/\s+/g, '');
+        if (previous.startsWith(text)) return;
+        previous = text;
+        clearTimeout(timeout);
+        timeout = setTimeout(() => handler(text), 100);
+    });
+})();

--- a/PC_Steam_Danganronpa_Trigger_Happy_Havoc.js
+++ b/PC_Steam_Danganronpa_Trigger_Happy_Havoc.js
@@ -1,0 +1,36 @@
+// ==UserScript==
+// @name         Danganronpa: Trigger Happy Havoc
+// @version      0.1
+// @author       [blacktide082]
+// @description  Steam
+// * Spike Chunsoft
+//
+// https://store.steampowered.com/app/413410/Danganronpa_Trigger_Happy_Havoc/
+// ==/UserScript==
+
+const __e = Process.enumerateModules()[0];
+const handler = trans.send(s => s, '200+');
+
+(function () {
+    const dialogSig = '89 ?? ?? 89 ?? ?? 8D ?? ?? ???????? 0FB7 ?? 83 ?? ?? 75 ?? 8B';
+    const results = Memory.scanSync(__e.base, __e.size, dialogSig);
+    if (results.length === 0) {
+        console.error('[DialoguePattern] Hook not found!');
+        return;
+    }
+
+    let text = '';
+    const address = results[0].address.add(0xD);
+    console.log('[DialoguePattern] Found hook', address);
+
+    Interceptor.attach(address, function (args) {
+        const value = this.context.ecx.readUtf16String()
+            .replace(/<CLT\s?\d*?>/g, '')
+            .replaceAll('\n', '')
+            .trim();
+        if (!text.endsWith(value)) {
+            text = value;
+            handler(text);
+        }
+    });
+})();

--- a/PC_Steam_Danganronpa_V3_Killing_Harmony.js
+++ b/PC_Steam_Danganronpa_V3_Killing_Harmony.js
@@ -1,0 +1,38 @@
+// ==UserScript==
+// @name         Danganronpa V3: Killing Harmony
+// @version      0.1
+// @author       [blacktide082]
+// @description  Steam
+// * Spike Chunsoft
+//
+// https://store.steampowered.com/app/567640/Danganronpa_V3_Killing_Harmony/
+// ==/UserScript==
+
+const __e = Process.enumerateModules()[0];
+const handler = trans.send(s => s, '100+');
+
+(function () {
+    // Dangan3Win.exe+3596E0 - E8 BB2F3500
+    const dialogSig = 'E8 BB?????? 48 ?? ?? ?? ?? 48 ?? ?? E8 7E?????? 0F28 ?? ?? ?? 48 ?? ?? ?? 5B';
+    const results = Memory.scanSync(__e.base, __e.size, dialogSig);
+    if (results.length === 0) {
+        console.error('[DialoguePattern] Hook not found!');
+        return;
+    }
+
+    const address = results[0].address;
+    console.log('[DialoguePattern] Found hook', address);
+
+    let timeout = 0;
+    Interceptor.attach(address, function (args) {
+        const text = args[0].readUtf16String()
+            .split('\n')
+            .map(line => line.trim())
+            .join('')
+            .replace(/\s+/, '') // remove whitespace
+            .replace(/<PAD=【(.+)】>/g, '（$1）') // reformat button glyphs
+            .replace(/<[^>]+>/g, ''); // remove remaining <> tags
+        clearTimeout(timeout);
+        timeout = setTimeout(() => handler(text), 100);
+    });
+})();


### PR DESCRIPTION
Adds scripts for the following games (Steam):

- Danganronpa: Trigger Happy Havoc
- Danganronpa 2: Goodbye Despair
- Danganronpa V3: Killing Harmony
- Danganronpa Another Episode: Ultra Despair Girls

Screenshot:

![PC_Steam_Danganronpa_Trigger_Happy_Havoc](https://github.com/0xDC00/scripts/assets/61211787/52cafeed-0ea6-4dfe-bfae-7ab3862b97c6)
