### PR TITLE
Resolve issues with local storage when using Agent v0.1.3

### DIFF
--- a/libPPSSPP.js
+++ b/libPPSSPP.js
@@ -221,6 +221,12 @@ function setHook(object) {
         }
     }
 
+    // localStorage support wasn't added until v0.1.4
+    // so prevent failure on earlier versions
+    if (localStorage.length === undefined) {
+        return;
+    }
+
     Object.keys(localStorage).map(key => {
         const value = localStorage.getItem(key);
         if (key.startsWith('PSP_') === true) {

--- a/libRPCS3.js
+++ b/libRPCS3.js
@@ -152,6 +152,12 @@ function setHook(object) {
         }
     }
 
+    // localStorage support wasn't added until v0.1.4
+    // so prevent failure on earlier versions
+    if (localStorage.length === undefined) {
+        return;
+    }
+
     Object.keys(localStorage).map(key => {
         const value = localStorage.getItem(key);
         if (key.startsWith('PS3_') === true) {

--- a/libVita3k.js
+++ b/libVita3k.js
@@ -153,6 +153,12 @@ function setHook(object) {
         }
     }
 
+    // localStorage support wasn't added until v0.1.4
+    // so prevent failure on earlier versions
+    if (localStorage.length === undefined) {
+        return;
+    }
+
     Object.keys(localStorage).map(key => {
         const value = localStorage.getItem(key);
         if (key.startsWith('PSVita_') === true) {

--- a/libYuzu.js
+++ b/libYuzu.js
@@ -306,6 +306,12 @@ function setHook(object, dfVer) {
 
     if (globalThis.gameVer) console.warn('Game version: ' + globalThis.gameVer);
 
+    // localStorage support wasn't added until v0.1.4
+    // so prevent failure on earlier versions
+    if (localStorage.length === undefined) {
+        return;
+    }
+
     Object.keys(localStorage).map(key => {
         const value = localStorage.getItem(key);
         if (key.startsWith('Yuzu_') === true) {


### PR DESCRIPTION
New localStorage updates broke older versions of Agent. We should probably add this for backwards compatibility with the older versions.

<img src="https://github.com/0xDC00/scripts/assets/61211787/cdc7efc2-5cbc-4ac1-8b9d-5b03f942fa4a" width=400>