### PR TITLE
Sora no Kiseki trilogy edits

### DIFF
--- a/PSVita_PCSG00489_Sora_no_Kiseki_SC_Evolution.js
+++ b/PSVita_PCSG00489_Sora_no_Kiseki_SC_Evolution.js
@@ -83,6 +83,18 @@ function _lootAndHandBooksHandler(regs, index, offset, hookName) {
     let info = address.readShiftJisString();
     if (SHOW_HOOK_NAME) console.warn(hookName);
 
+    if(info.includes("を修得した。")) { // When obtaining a new craft in case at least two characters get a new one
+        if(!infoContent.includes(info)) { 
+            infoContent.push(info);
+            return info;
+        }
+    
+        if(infoContent.includes(info)) { 
+            resetInfoTimer();
+            return null;
+        }
+    }
+
     if (hookName === "other text")
         previousQuest = ""; // To display the quest at the top of the list again if it was the last one selected (in handbook)
 
@@ -341,5 +353,7 @@ trans.replace(function (s) {
         .replace(/\\n/g, '\n')      // make the extracted '\n' actually act as a new line
         .replace(/\b\d{1,2}\/\s\d{1,2}\b/g, '') // remove things like '5/ 0' on recipe page
         .replace(/\b\d{1,2}\/\d{1,2}\b/g, '') // remove things like '5/10' on recipe page
+        .replace(/【氏\s名】/, "【氏名】")
+        .replace(/【所\s属/, "【所属")
         .trim();
 });

--- a/PSVita_PCSG00490_Sora_no_Kiseki_the_3rd_Evolution.js
+++ b/PSVita_PCSG00490_Sora_no_Kiseki_the_3rd_Evolution.js
@@ -96,6 +96,18 @@ function _lootAndHandBooksHandler(regs, index, offset, hookName) {
     const address = regs[index].value.add(offset);
     let info = address.readShiftJisString();
 
+    if(info.includes("を修得した。")) { // When obtaining a new craft in case at least two characters get a new one
+        if(!infoContent.includes(info)) { 
+            infoContent.push(info);
+            return info;
+        }
+    
+        if(infoContent.includes(info)) { 
+            resetInfoTimer();
+            return null;
+        }
+    }
+
     if (hookName === "other text" && info.includes("【属性:") || /^.{1,3}：/.test(info))
         return null; // The hook overlaps with quartz and arts info
 


### PR DESCRIPTION
Fixing the issue where only the first message gets extracted when more than one character gains a new craft upon leveling up in all three Sora no Kiseki games (FC, SC, and the 3rd), fixing the duplicated incomplete message from the main text in FC, and minor format changes in FC and SC.