### PR TITLE
Add VNDB name for Jyuzaengi

### DIFF
--- a/NS_01003D2017FEA000_Jyuzaengi_Engetsu_Sangokuden_1_and_2.js
+++ b/NS_01003D2017FEA000_Jyuzaengi_Engetsu_Sangokuden_1_and_2.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [01003D2017FEA000] 十三支演義 偃月三国伝1・2 for Nintendo Switch
+// @name         [01003D2017FEA000] 十三支演義 偃月三国伝1・2 for Nintendo Switch (Juuzaengi ~Engetsu Sangokuden~)
 // @version      1.0.0
 // @author       [zooo]
 // @description  Yuzu


### PR DESCRIPTION
I almost could not find the script for "Jyuzaengi" because I searched the repo with "Juuzaengi", the game's name in [VNDB](https://vndb.org/v10289), and GitHub returned 0 results. Including the VNDB name in the script should make it more discoverable.