### PR TITLE
Add PCSX2 hook support

### DIFF
--- a/PS2_SLPM-66302_Clannad.js
+++ b/PS2_SLPM-66302_Clannad.js
@@ -1,0 +1,25 @@
+// ==UserScript==
+// @name         PS2_SLPM-66302_Clannad.js
+// @version      0.0
+// @author       logantgt
+// @description  PCSX2 x64
+// ==/UserScript==
+
+const { setHookEE } = require("./libPCSX2.js");
+const { asPsxPtr } = require("./libPCSX2.js");
+
+setHookEE({
+    0x14AC38: trans.send(handler)
+});
+
+function handler(args) {
+        /* processString */
+        let s = this.context.s4(asPsxPtr).readShiftJisString().split(");")[0];
+        s = s
+            .replace(/(\\n)+/g, ' ')  
+            .replace(/\\d$|^\@[a-z]+|#.*?#|\$/g, '')
+            .replace(/\u3000+/gu, '')
+            .replace(/@w|\\c/g, '');
+    
+        return s;
+}

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -39,8 +39,11 @@ Interceptor.attach(recRecompile, {
 
 function jitAttachEE(startpc, recPtr, op)
 {
+    const thiz = Object.create(null, {});
+    thiz.context = context;
+
     Breakpoint.add(recPtr, () => {
-        op.call(op[0], context);
+        op.call(thiz, op[0]);
         sessionStorage.setItem('PCSX2_EE_' + Date.now(), {
             guest: startpc,
             host: recPtr
@@ -67,8 +70,11 @@ Interceptor.attach(iopRecRecompile, {
 
 function jitAttachIOP(startpc, recPtr, op)
 {
+    const thiz = Object.create(null, {});
+    thiz.context = context;
+
     Breakpoint.add(recPtr, () => {
-        op.call(op[0], context);
+        op.call(thiz, op[0]);
         sessionStorage.setItem('PCSX2_IOP_' + Date.now(), {
             guest: startpc,
             host: recPtr

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -1,0 +1,326 @@
+// @name         PCSX2 JIT Hooker
+// @version      2.2.0
+// @author       logantgt, based on work from [DC] and koukdw 
+// @description  windows, linux, mac (x64)
+
+// ?New@BaseBlocks@@QEAAPEAUBASEBLOCKEX@@I_K@Z
+const BaseBlocks$New = DebugSymbol.findFunctionsNamed('BaseBlocks::New')[0];
+const recRecompile = DebugSymbol.findFunctionsNamed('recRecompile')[0];
+const iopRecRecompile = DebugSymbol.findFunctionsNamed('iopRecRecompile')[0];
+const recAddBreakpoint = DebugSymbol.findFunctionsNamed('CBreakPoints::AddBreakPoint')[0];
+
+const operations = Object.create(null);
+
+const cache = new Map();
+Interceptor.attach(BaseBlocks$New, function (args) {
+    const startpc = args[1].toUInt32();
+    const recPtr = args[2];
+    cache.set(startpc, recPtr);
+    //console.warn('New 0x' + startpc.toString(16) + ' ' + recPtr);
+});
+
+Interceptor.attach(recRecompile, {
+    onEnter(args) {
+        this.startpc = args[0].toUInt32();
+    },
+    onLeave() {
+        const startpc = this.startpc;
+        const recPtr = cache.get(startpc);
+
+        const op = operations[startpc];
+        if (op !== undefined) {
+            console.log('Attach EE:', ptr(startpc));
+            Breakpoint.add(recPtr, () => {
+                op.call(op[0], ctx);
+            });
+        }
+
+        // console.log('recRecompile: 0x' + startpc.toString(16) + ' -> ' + recPtr);
+    }
+});
+
+Interceptor.attach(iopRecRecompile, {
+    onEnter(args) {
+        this.startpc = args[0].toUInt32();
+    },
+    onLeave() {
+        const startpc = this.startpc;
+        const recPtr = cache.get(startpc);
+
+        const op = operations[startpc];
+        if (op !== undefined) {
+            console.log('Attach IOP:', ptr(startpc));
+            Breakpoint.add(recPtr, () => {
+                op.call(op[0], ctx);
+            });
+        }
+        // console.log('iopRecRecompile: 0x' + startpc.toString(16) + ' -> ' + recPtr);
+    }
+});
+
+const symbols = Process.mainModule.enumerateSymbols();
+
+const eeMem = symbols.find(x => x.name === 'eeMem').address.readPointer();
+const cpuRegsPtr = symbols.find(x => x.name === '_cpuRegistersPack').address;
+const iopMem = symbols.find(x => x.name ===  'iopMem').address.readPointer();
+const psxRegsPtr = symbols.find(x => x.name === 'psxRegs').address;
+
+
+// regs functions take a Typed Array View and run the constructor
+// (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Typed_arrays)
+const eeRegs = {
+    r0: function(view) {
+        return new view(cpuRegsPtr.readByteArray(16))
+    },
+    at: function(view) {
+        return new view(cpuRegsPtr.add(16).readByteArray(16))
+    },
+    v0: function(view) {
+        return new view(cpuRegsPtr.add(32).readByteArray(16))
+    },
+    v1: function(view) {
+        return new view(cpuRegsPtr.add(48).readByteArray(16))
+    },
+    a0: function(view) {
+        return new view(cpuRegsPtr.add(64).readByteArray(16))
+    },
+    a1: function(view) {
+        return new view(cpuRegsPtr.add(80).readByteArray(16))
+    },
+    a2: function(view) {
+        return new view(cpuRegsPtr.add(96).readByteArray(16))
+    },
+    a3: function(view) {
+        return new view(cpuRegsPtr.add(112).readByteArray(16))
+    },
+    t0: function(view) {
+        return new view(cpuRegsPtr.add(128).readByteArray(16))
+    },
+    t1: function(view) {
+        return new view(cpuRegsPtr.add(144).readByteArray(16))
+    },
+    t2: function(view) {
+        return new view(cpuRegsPtr.add(160).readByteArray(16))
+    },
+    t3: function(view) {
+        return new view(cpuRegsPtr.add(176).readByteArray(16))
+    },
+    t4: function(view) {
+        return new view(cpuRegsPtr.add(192).readByteArray(16))
+    },
+    t5: function(view) {
+        return new view(cpuRegsPtr.add(208).readByteArray(16))
+    },
+    t6: function(view) {
+        return new view(cpuRegsPtr.add(224).readByteArray(16))
+    },
+    t7: function(view) {
+        return new view(cpuRegsPtr.add(240).readByteArray(16))
+    },
+    s0: function(view) {
+        return new view(cpuRegsPtr.add(256).readByteArray(16))
+    },
+    s1: function(view) {
+        return new view(cpuRegsPtr.add(272).readByteArray(16))
+    },
+    s2: function(view) {
+        return new view(cpuRegsPtr.add(288).readByteArray(16))
+    },
+    s3: function(view) {
+        return new view(cpuRegsPtr.add(304).readByteArray(16))
+    },
+    s4: function(view) {
+        return new view(cpuRegsPtr.add(320).readByteArray(16))
+    },
+    s5: function(view) {
+        return new view(cpuRegsPtr.add(336).readByteArray(16))
+    },
+    s6: function(view) {
+        return new view(cpuRegsPtr.add(352).readByteArray(16))
+    },
+    s7: function(view) {
+        return new view(cpuRegsPtr.add(368).readByteArray(16))
+    },
+    t8: function(view) {
+        return new view(cpuRegsPtr.add(384).readByteArray(16))
+    },
+    t9: function(view) {
+        return new view(cpuRegsPtr.add(400).readByteArray(16))
+    },
+    k0: function(view) {
+        return new view(cpuRegsPtr.add(416).readByteArray(16))
+    },
+    k1: function(view) {
+        return new view(cpuRegsPtr.add(432).readByteArray(16))
+    },
+    gp: function(view) {
+        return new view(cpuRegsPtr.add(448).readByteArray(16))
+    },
+    sp: function(view) {
+        return new view(cpuRegsPtr.add(464).readByteArray(16))
+    },
+    s8: function(view) {
+        return new view(cpuRegsPtr.add(480).readByteArray(16))
+    },
+    ra: function(view) {
+        return new view(cpuRegsPtr.add(496).readByteArray(16))
+    }
+}
+
+const iopRegs = {
+    r0: function(view) {
+        return new view(psxRegsPtr.readByteArray(4))
+    },
+    at: function(view) {
+        return new view(psxRegsPtr.add(4).readByteArray(4))
+    },
+    v0: function(view) {
+        return new view(psxRegsPtr.add(8).readByteArray(4))
+    },
+    v1: function(view) {
+        return new view(psxRegsPtr.add(12).readByteArray(4))
+    },
+    a0: function(view) {
+        return new view(psxRegsPtr.add(16).readByteArray(4))
+    },
+    a1: function(view) {
+        return new view(psxRegsPtr.add(20).readByteArray(4))
+    },
+    a2: function(view) {
+        return new view(psxRegsPtr.add(24).readByteArray(4))
+    },
+    a3: function(view) {
+        return new view(psxRegsPtr.add(28).readByteArray(4))
+    },
+    t0: function(view) {
+        return new view(psxRegsPtr.add(32).readByteArray(4))
+    },
+    t1: function(view) {
+        return new view(psxRegsPtr.add(36).readByteArray(4))
+    },
+    t2: function(view) {
+        return new view(psxRegsPtr.add(40).readByteArray(4))
+    },
+    t3: function(view) {
+        return new view(psxRegsPtr.add(44).readByteArray(4))
+    },
+    t4: function(view) {
+        return new view(psxRegsPtr.add(48).readByteArray(4))
+    },
+    t5: function(view) {
+        return new view(psxRegsPtr.add(52).readByteArray(4))
+    },
+    t6: function(view) {
+        return new view(psxRegsPtr.add(56).readByteArray(4))
+    },
+    t7: function(view) {
+        return new view(psxRegsPtr.add(60).readByteArray(4))
+    },
+    s0: function(view) {
+        return new view(psxRegsPtr.add(64).readByteArray(4))
+    },
+    s1: function(view) {
+        return new view(psxRegsPtr.add(68).readByteArray(4))
+    },
+    s2: function(view) {
+        return new view(psxRegsPtr.add(72).readByteArray(4))
+    },
+    s3: function(view) {
+        return new view(psxRegsPtr.add(76).readByteArray(4))
+    },
+    s4: function(view) {
+        return new view(psxRegsPtr.add(80).readByteArray(4))
+    },
+    s5: function(view) {
+        return new view(psxRegsPtr.add(84).readByteArray(4))
+    },
+    s6: function(view) {
+        return new view(psxRegsPtr.add(88).readByteArray(4))
+    },
+    s7: function(view) {
+        return new view(psxRegsPtr.add(92).readByteArray(4))
+    },
+    t8: function(view) {
+        return new view(psxRegsPtr.add(96).readByteArray(4))
+    },
+    t9: function(view) {
+        return new view(psxRegsPtr.add(100).readByteArray(4))
+    },
+    k0: function(view) {
+        return new view(psxRegsPtr.add(104).readByteArray(4))
+    },
+    k1: function(view) {
+        return new view(psxRegsPtr.add(108).readByteArray(4))
+    },
+    gp: function(view) {
+        return new view(psxRegsPtr.add(112).readByteArray(4))
+    },
+    sp: function(view) {
+        return new view(psxRegsPtr.add(116).readByteArray(4))
+    },
+    s8: function(view) {
+        return new view(psxRegsPtr.add(120).readByteArray(4))
+    },
+    ra: function(view) {
+        return new view(psxRegsPtr.add(124).readByteArray(4))
+    }
+}
+
+const ctx = {
+    eeMem,
+    eeRegs,
+    iopMem,
+    iopRegs
+}
+
+const dynarecCheckBreakpoint = symbols.find(x => x.name === 'dynarecCheckBreakpoint');
+
+// NOP dynarecCheckBreakpoint (for EE)
+// This results in the same outcome as creating a breakpoint with an unsatisfiable condition in the UI (like 1 < 0)
+Memory.patchCode(dynarecCheckBreakpoint.address, dynarecCheckBreakpoint.size, function (code)
+  {
+    const cw = new X86Writer(code, {pc: dynarecCheckBreakpoint.address});
+    cw.putNopPadding(dynarecCheckBreakpoint.size);
+    cw.putRet();
+    cw.flush();
+  }
+);
+
+const psxDynarecCheckBreakpoint = symbols.find(x => x.name === 'psxDynarecCheckBreakpoint');
+
+// NOP psxDynarecCheckBreakpoint (for IOP)
+Memory.patchCode(psxDynarecCheckBreakpoint.address, psxDynarecCheckBreakpoint.size, function (code)
+  {
+    const cw = new X86Writer(code, {pc: psxDynarecCheckBreakpoint.address});
+    cw.putNopPadding(psxDynarecCheckBreakpoint.size);
+    cw.putRet();
+    cw.flush();
+  }
+);
+
+async function setHookEE(object) {
+    for (const key in object) {
+        if (Object.hasOwnProperty.call(object, key)) {
+            const element = object[key];
+            operations[key] = element;
+            var addBp = new NativeFunction(recAddBreakpoint, 'void', ['uint8', 'uint32', 'bool', 'bool']);
+            addBp(0x01, parseInt(key), 0x00, 0x01);
+        }
+    }
+}
+
+async function setHookIOP(object) {
+    for (const key in object) {
+        if (Object.hasOwnProperty.call(object, key)) {
+            const element = object[key];
+            operations[key] = element;
+            var addBp = new NativeFunction(recAddBreakpoint, 'void', ['uint8', 'uint32', 'bool', 'bool']);
+            addBp(0x00, parseInt(key), 0x00, 0x01);
+        }
+    }
+}
+
+module.exports = exports = {
+    setHookEE,
+    setHookIOP
+}

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -273,30 +273,14 @@ const ctx = {
     iopRegs
 }
 
-const dynarecCheckBreakpoint = symbols.find(x => x.name === 'dynarecCheckBreakpoint');
-
-// NOP dynarecCheckBreakpoint (for EE)
+// replace dynarecCheckBreakpoint (for EE)
 // This results in the same outcome as creating a breakpoint with an unsatisfiable condition in the UI (like 1 < 0)
-Memory.patchCode(dynarecCheckBreakpoint.address, dynarecCheckBreakpoint.size, function (code)
-  {
-    const cw = new X86Writer(code, {pc: dynarecCheckBreakpoint.address});
-    cw.putNopPadding(dynarecCheckBreakpoint.size);
-    cw.putRet();
-    cw.flush();
-  }
-);
+const dynarecCheckBreakpoint = symbols.find(x => x.name === 'dynarecCheckBreakpoint');
+Interceptor.replace(dynarecCheckBreakpoint.address, new NativeCallback(() => { return; }, 'void', []));
 
+// replace psxDynarecCheckBreakpoint (for IOP)
 const psxDynarecCheckBreakpoint = symbols.find(x => x.name === 'psxDynarecCheckBreakpoint');
-
-// NOP psxDynarecCheckBreakpoint (for IOP)
-Memory.patchCode(psxDynarecCheckBreakpoint.address, psxDynarecCheckBreakpoint.size, function (code)
-  {
-    const cw = new X86Writer(code, {pc: psxDynarecCheckBreakpoint.address});
-    cw.putNopPadding(psxDynarecCheckBreakpoint.size);
-    cw.putRet();
-    cw.flush();
-  }
-);
+Interceptor.replace(psxDynarecCheckBreakpoint.address, new NativeCallback(() => { return; }, 'void', []));
 
 async function setHookEE(object) {
     for (const key in object) {

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -31,7 +31,7 @@ Interceptor.attach(recRecompile, {
         if (op !== undefined) {
             console.log('Attach EE:', ptr(startpc));
             Breakpoint.add(recPtr, () => {
-                op.call(op[0], ctx);
+                op.call(op[0], context);
             });
         }
 
@@ -51,7 +51,7 @@ Interceptor.attach(iopRecRecompile, {
         if (op !== undefined) {
             console.log('Attach IOP:', ptr(startpc));
             Breakpoint.add(recPtr, () => {
-                op.call(op[0], ctx);
+                op.call(op[0], context);
             });
         }
         // console.log('iopRecRecompile: 0x' + startpc.toString(16) + ' -> ' + recPtr);
@@ -64,7 +64,6 @@ const eeMem = symbols.find(x => x.name === 'eeMem').address.readPointer();
 const cpuRegsPtr = symbols.find(x => x.name === '_cpuRegistersPack').address;
 const iopMem = symbols.find(x => x.name ===  'iopMem').address.readPointer();
 const psxRegsPtr = symbols.find(x => x.name === 'psxRegs').address;
-
 
 // regs functions take a Typed Array View and run the constructor
 // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Typed_arrays)
@@ -266,7 +265,7 @@ const iopRegs = {
     }
 }
 
-const ctx = {
+const context = {
     eeMem,
     eeRegs,
     iopMem,
@@ -299,12 +298,18 @@ async function setHookIOP(object) {
             const element = object[key];
             operations[key] = element;
             var addBp = new NativeFunction(recAddBreakpoint, 'void', ['uint8', 'uint32', 'bool', 'bool']);
-            addBp(0x00, parseInt(key), 0x00, 0x01);
+            addBp(0x02, parseInt(key), 0x00, 0x01);
         }
     }
 }
 
+function asPsxPtr(bytes)
+{
+    return context.eeMem.add(ptr(new Uint32Array(bytes)[0]));
+}
+
 module.exports = exports = {
     setHookEE,
-    setHookIOP
+    setHookIOP,
+    asPsxPtr
 }


### PR DESCRIPTION
A simple script for hooking PS2 instructions in the PCSX2 JIT.

The script exports functions for hooking into both the EE and IOP and offers a simple interface for retrieving memory, and registers as any type, by passing in the relevant constructor method where a byte array of the data in the register is passed in as an argument.

```js
this.context.s4(Uint32Array)[0]; // read the lowest 32-bit number out of register s4 on the hooked CPU using a Typed Array View
```

A very rudimentary hook might look like;
```js
const { setHookEE } = require("./libPCSX2.js");
const { asPsxPtr } = require("./libPCSX2.js");

setHookEE({
    0x14AC38: trans.send(handler)
});

function handler(args) {
        /* processString */
        let s = this.context.s4(asPsxPtr).readShiftJisString().split(");")[0];
        s = s
            .replace(/(\\n)+/g, ' ')  
            .replace(/\\d$|^\@[a-z]+|#.*?#|\$/g, '')
            .replace(/\u3000+/gu, '')
            .replace(/@w|\\c/g, '');
    
        return s;
}
```
It should be possible to hook any PS2 instruction using this method, since calls are made internally to create breakpoints which forces the JIT to cache new translation blocks with the relevant instruction at the very beginning.

Thanks @koukdw for providing invaluable assistance and documentation, and for sending a basic implementation by @0xDC00 which got me started.