### PR TITLE
Fix Gensou Kissa Enchante version metadata

### DIFF
--- a/NS_010079200C26E000_Gensou_Kissa_Enchante.js
+++ b/NS_010079200C26E000_Gensou_Kissa_Enchante.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         [010079200C26E000] Gensou Kissa Enchanté
-// @version      1.0.4
+// @version      1.0.0
 // @author       Mansive
 // @description  Yuzu, Ryujinx
 // * Design Factory Co., Ltd. & Otomate


### PR DESCRIPTION
Metadata has 1.0.4 for the version, but the game doesn't have a version 1.0.4