### PR TITLE
Add a second hook for names to the Ni No Kuni script

### DIFF
--- a/PC_Steam_Ni.No.Kuni.Wrath.Of.The.White.Witch.Remastered.js
+++ b/PC_Steam_Ni.No.Kuni.Wrath.Of.The.White.Witch.Remastered.js
@@ -1,38 +1,76 @@
 // ==UserScript==
 // @name         Ni no Kuni Wrath of the White Witch™ Remastered
-// @version      0.2
-// @author       aqui
+// @version      0.3
+// @author       aqui, robbert-vdh
 // @description  Steam
 // * Level-5
 //
 // https://store.steampowered.com/app/798460/Ni_no_Kuni_Wrath_of_the_White_Witch_Remastered/
 // ==/UserScript==
 const __e = Process.enumerateModules()[0];
-const handlerLine = trans.send((s) => s, '250+');
+const handlerLine = trans.send((s) => s, "250+");
 
-// dialogues and descriptions
+const hooks = [
+  {
+    // Dialogue and descriptions
+    name: "Dialogue",
+    signature: "0F?? ?? ?? ???????? 49 ?? ?? 46 ?? ?? ?? 75 ?? 48 ?? ?? ?? E8", // E8 2EBDF2FF
+    address: null,
+  },
+  {
+    // Item and character names
+    name: "Names",
+    signature: "48 ?? ?? 74 1D C6 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? CB E8", // E8 371FADFF
+    address: null,
+  },
+];
+
 (function () {
-    const dialogSig1 = '0F?? ?? ?? ???????? 49 ?? ?? 46 ?? ?? ?? 75 ?? 48 ?? ?? ?? E8'; //E8 2EBDF2FF
-    const results = Memory.scanSync(__e.base, __e.size, dialogSig1);
+  for (const hook of hooks) {
+    const results = Memory.scanSync(__e.base, __e.size, hook.signature);
     if (results.length === 0) {
-        console.error('[DialoguesPattern] no result!');
+      console.error(`Could not find the signature for '${hook.name}'`);
+      return;
+    } else if (results.length > 1) {
+      console.error(`Multiple signatures for '${hook.name}' found (${results.length} results)`);
+      return;
+    } else {
+      // `results[0].address` points to the start of the signature, and we want
+      // the address of the `call` (0xE8) instruction, so we need to count the
+      // number of bytes up until that point
+      if (!hook.signature.match(/^([0-9A-F?]{2} *)+E8$/)) {
+        console.error(`The signature for '${hook.name}' does not match the expected format, this is an issue with the script`);
         return;
+      }
+
+      const prefixHexBytes = hook.signature
+        .slice(0, hook.signature.length - 2)
+        .replaceAll(" ", "");
+      const address = results[0].address.add(prefixHexBytes.length / 2);
+
+      console.log(`[${hook.name}]: ${address}`);
+      hook.address = address;
     }
-    let hookAddress = results[0].address.add(0x15)
-    console.log('[DialoguesPattern] ' + hookAddress);
+  }
 
-    let lastTwentyStrings = []
+  for (const hook of hooks) {
+    const lastTwentyStrings = [];
+    Interceptor.attach(hook.address, {
+      onEnter(args) {
+        const newString = args[1]
+          .readCString()
+          .replace(/<[^>]*>/g, "")
+          .replace(/\[(.*?)\/(.*?)\]/g, "$1")
+          .replace(/\\n/g, "\n");
 
-    Interceptor.attach(hookAddress, {
-        onEnter(args) {
-            let newString = args[1].readCString().replace(/<[^>]*>/g, '').replace(/\[(.*?)\/(.*?)\]/g, "$1").replace(/\\n/g, "\n")
-            if (!lastTwentyStrings.includes(newString)) {
-                handlerLine(newString)
-                lastTwentyStrings.push(newString)
-                if (lastTwentyStrings.size > 20) {
-                    lastTwentyStrings.shift()
-                }
-            }
-        },
+        if (!lastTwentyStrings.includes(newString)) {
+          handlerLine(newString);
+          lastTwentyStrings.push(newString);
+          if (lastTwentyStrings.size > 20) {
+            lastTwentyStrings.shift();
+          }
+        }
+      },
     });
+  }
 })();


### PR DESCRIPTION
This adds a second hook to the Ni No Kuni script that is used to render item names, character names, and some other single line texts. That duplicate lines filter doesn't seem to be necessary for this function (it is for the one that handles the dialogue text), but I kept it in for consistency's sake.

CC @aquiab