### PR TITLE
Update the KirikiriZ lib and the Tsuyuchiru Letter script

### DIFF
--- a/PC_Steam_KiriKiriZ_Tsuyuchiru_Letter_Umi_to_Shiori_ni_Amaoto_o.js
+++ b/PC_Steam_KiriKiriZ_Tsuyuchiru_Letter_Umi_to_Shiori_ni_Amaoto_o.js
@@ -14,13 +14,6 @@
 const engine = require('./libPCKiriKiriZ.js');
 
 engine.hookTextrenderDll(function (text) {
-    text = cleanText(text);
     trans.send(text);
     return text;
 });
-
-function cleanText(text) {
-    return text
-        .replace(/\[[^\]]*\]/g, '') // Furigana
-        .replace(/\\n/g, ' ');
-}

--- a/libPCKiriKiriZ.js
+++ b/libPCKiriKiriZ.js
@@ -15,6 +15,7 @@ function hookTextrenderDll(callback) {
         if (timer !== null) {
             const address = this.context.eax;
             let s = address.readUtf16String();
+            s = cleanText(s);
             callback.call(null, s);
         }
 
@@ -47,4 +48,11 @@ function hookTextrenderDll(callback) {
 
 module.exports = exports = {
     hookTextrenderDll
+};
+
+function cleanText(text) {
+    return text
+        .replace(/\[[^\]]*\]/g, '') // Furigana
+        .replace(/%[^;]*;/g, '') // Font change?
+        .replace(/\\n/g, ' ');
 }


### PR DESCRIPTION
Add regex in the lib, remove the regex in the Tsuyuchiru script to avoid redundancy.
The scripts making use of the KirikiriZ lib are virtually identical since any can be used, returning the same results.