### PR TITLE
Make libPCSX2 work without debug symbols

### DIFF
--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -90,23 +90,16 @@ function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
         return null;
     }
 
-    const patternAddress = getPatternAddress({ name, pattern });
-    const base = patternAddress.sub(lookbackSize);
+    const address = getPatternAddress({ name, pattern });
+    const base = address.sub(lookbackSize);
     const size = lookbackSize;
+    const patterns = ["CC 4?", "CC 5?"];
 
-    {
-        const results = Memory.scanSync(base, size, "CC 4?");
-        const address = findFunctionStartAddress(results);
-        if (address !== null) {
-            return address;
-        }
-    }
-
-    {
-        const results = Memory.scanSync(base, size, "CC 5?");
-        const address = findFunctionStartAddress(results);
-        if (address !== null) {
-            return address;
+    for (const pattern of patterns) {
+        const results = Memory.scanSync(base, size, pattern);
+        const startAddress = findFunctionStartAddress(results);
+        if (startAddress !== null) {
+            return startAddress;
         }
     }
 

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -1,5 +1,5 @@
 // @name         PCSX2 JIT Hooker
-// @version      2.2.0 -> 2.3.257
+// @version      2.2.0 -> 2.3.260
 // @author       logantgt, Mansive, based on work from [DC] and koukdw
 // @description  windows, linux, mac (x64)
 

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -11,8 +11,12 @@ const IS_DEBUG = false;
 const FORCE_PATTERN_FALLBACK = false;
 
 const __e = Process.mainModule;
-__e.size /= 2;
 
+console.warn("[Compatibility]");
+console.warn("PCSX2 v2.2.0+");
+console.log("[Mirror] Download: https://github.com/koukdw/emulators/releases");
+
+__e.size /= 2;
 const symbols = __e.enumerateSymbols();
 // console.log(JSON.stringify(Process.mainModule.enumerateSymbols(), null, 2));
 

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -99,6 +99,8 @@ function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
         const results = Memory.scanSync(base, size, pattern);
         const startAddress = findFunctionStartAddress(results);
         if (startAddress !== null) {
+            if (IS_DEBUG) console.log(`[${name}Prologue] @ ${address}`);
+
             return startAddress;
         }
     }
@@ -161,8 +163,8 @@ function findAddressesThroughPattern() {
     addresses["recAddBreakpoint"] = getFunctionAddress({
         name: "recAddBreakpoint",
         lookbackSize: 0x500,
-        pattern: "48 83 05 ?? ?? ?? 0D 50 EB 14 48 8D 0D ?? ?? ?? 0D 4C 8D 44 24 ?? ?? 89 FA E8",
-        //       "48 83 05 4E 54 46 0D 50 EB 14 48 8D 0D 3D 54 46 0D 4C 8D 44 24 28 48 89 FA E8 98 17 00 00"
+        pattern: "48 83 05 ???????? 50 EB 14 48 8D 0D ???????? 4C 8D 44 24 ?? ?? 89 FA E8",
+        //       "48 83 05 4E54460D 50 EB 14 48 8D 0D 3D54460D 4C 8D 44 24 28 48 89 FA E8 98170000"
     });
 
     {

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -16,7 +16,7 @@ __e.size /= 2;
 const symbols = __e.enumerateSymbols();
 // console.log(JSON.stringify(Process.mainModule.enumerateSymbols(), null, 2));
 
-//#region Find Addresses
+// #region Find Addresses
 
 /** @type {Object.<string, NativePointer>} */
 const addresses = Object.create(null);
@@ -131,7 +131,7 @@ function calculateLeaAddress(ins) {
 }
 
 // prettier-ignore
-function findAddressesThroughDebug() {
+function setAddressesThroughDebug() {
     // ?New@BaseBlocks@@QEAAPEAUBASEBLOCKEX@@I_K@Z
     addresses["baseBlocksNew"] = DebugSymbol.findFunctionsNamed("BaseBlocks::New")[0];
     addresses["recRecompile"] = DebugSymbol.findFunctionsNamed("recRecompile")[0];
@@ -145,8 +145,8 @@ function findAddressesThroughDebug() {
     addresses["psxDynarecCheckBreakpoint"] = findSymbol("psxDynarecCheckBreakpoint").address;
 }
 
-//prettier-ignore
-function findAddressesThroughPattern() {
+// prettier-ignore
+function setAddressesThroughPattern() {
     addresses["baseBlocksNew"] = getFunctionAddress({
         name: "baseBlocksNew",
         pattern: "4C 8B 40 08 41 80 78 19 00 0F84 ????0000",
@@ -214,12 +214,12 @@ if (
     FORCE_PATTERN_FALLBACK === false
 ) {
     console.warn("Using debug symbols");
-    findAddressesThroughDebug();
+    setAddressesThroughDebug();
 } else {
     console.warn("Using pattern scanning");
 
     try {
-        findAddressesThroughPattern();
+        setAddressesThroughPattern();
     } catch (err) {
         console.error(`
             \rFailed pattern scanning!
@@ -231,7 +231,7 @@ if (
     }
 }
 
-//#endregion
+// #endregion
 
 if (IS_DEBUG === true) {
     console.log("\nAddresses:");
@@ -322,7 +322,7 @@ function jitAttachIOP(startpc, recPtr, op) {
     });
 }
 
-//#region Contexts
+// #region Contexts
 
 // regs functions take a Typed Array View and run the constructor
 // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Typed_arrays)
@@ -526,9 +526,9 @@ const iopContext = {
     },
 };
 
-//#endregion
+// #endregion
 
-//prettier-ignore
+// prettier-ignore
 {
     // replace dynarecCheckBreakpoint (for EE)
     // This results in the same outcome as creating a breakpoint with an unsatisfiable condition in the UI (like 1 < 0)
@@ -538,7 +538,7 @@ const iopContext = {
     Interceptor.replace(psxDynarecCheckBreakpoint, new NativeCallback(() => { return; }, "void", []));
 }
 
-//prettier-ignore
+// prettier-ignore
 async function setHookEE(object) {
     for (const key in object) {
         if (Object.hasOwnProperty.call(object, key)) {
@@ -564,7 +564,7 @@ async function setHookEE(object) {
     });
 }
 
-//prettier-ignore
+// prettier-ignore
 async function setHookIOP(object) {
     for (const key in object) {
         if (Object.hasOwnProperty.call(object, key)) {

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -131,7 +131,7 @@ function calculateLeaAddress(ins) {
 }
 
 // prettier-ignore
-function setAddressesThroughDebug() {
+function setupAddressesThroughDebug() {
     // ?New@BaseBlocks@@QEAAPEAUBASEBLOCKEX@@I_K@Z
     addresses["baseBlocksNew"] = DebugSymbol.findFunctionsNamed("BaseBlocks::New")[0];
     addresses["recRecompile"] = DebugSymbol.findFunctionsNamed("recRecompile")[0];
@@ -146,27 +146,27 @@ function setAddressesThroughDebug() {
 }
 
 // prettier-ignore
-function setAddressesThroughPattern() {
+function setupAddressesThroughPattern() {
     addresses["baseBlocksNew"] = getFunctionAddress({
         name: "baseBlocksNew",
         pattern: "4C 8B 40 08 41 80 78 19 00 0F84 ????0000",
-        //       "4C 8B 40 08 41 80 78 19 00 0F84 76010000",
+        //       "4C 8B 40 08 41 80 78 19 00 0F84 76010000" v2.2.0
     });
     addresses["recRecompile"] = getFunctionAddress({
         name: "recCompile",
         pattern: "48 8B 05 ???????? 48 3B 05 ???????? 72 07",
-        //       "48 8B 05 DB0B8303 48 3B 05 DC0B8303 72 07 C6 05 F30B8B03 01",
+        //       "48 8B 05 DB0B8303 48 3B 05 DC0B8303 72 07 C6 05 F30B8B03 01" v2.2.0
     });
     addresses["iopRecRecompile"] = getFunctionAddress({
         name: "iopRecRecompile",
         pattern: "81 F9 30160000 0F 84 8A000000 81 FE 90080000",
-        //       "81 F9 30160000 0F 84 8A000000 81 FE 90080000",
+        //       "81 F9 30160000 0F 84 8A000000 81 FE 90080000" v2.2.0
     });
     addresses["recAddBreakpoint"] = getFunctionAddress({
         name: "recAddBreakpoint",
         lookbackSize: 0x500,
         pattern: "48 83 05 ???????? 50 EB 14 48 8D 0D ???????? 4C 8D 44 24 ?? ?? 89 FA E8",
-        //       "48 83 05 4E54460D 50 EB 14 48 8D 0D 3D54460D 4C 8D 44 24 28 48 89 FA E8 98170000"
+        //       "48 83 05 4E54460D 50 EB 14 48 8D 0D 3D54460D 4C 8D 44 24 28 48 89 FA E8 98170000" v2.2.0
     });
 
     {
@@ -175,7 +175,7 @@ function setAddressesThroughPattern() {
         const cpuRegsLoad = getPatternAddress({
             name: "cpuRegsLoad",
             pattern: "48 8D 15 ???????? 89 84 8A F0030000",
-            //       "48 8D 15 4F607A02 89 84 8A F0030000",
+            //       "48 8D 15 4F607A02 89 84 8A F0030000" v2.2.0
         });
         const ins = Instruction.parse(cpuRegsLoad); // lea rdx,[pcsx2-qt._cpuRegistersPack]
 
@@ -186,7 +186,7 @@ function setAddressesThroughPattern() {
         const psxRegsLoad = getPatternAddress({
             name: "psxRegsLoad",
             pattern: "4? ?? ?? 48 8D 15 ???????? 89 04 8A C3",
-            //       "41 8B 01 48 8D 15 3E4C7A02 89 04 8A C3",
+            //       "41 8B 01 48 8D 15 3E4C7A02 89 04 8A C3" v2.2.0
         });
         let ins = Instruction.parse(psxRegsLoad); // movsxd  rcx,r8d
         ins = Instruction.parse(ins.next); // lea rdx,[pcsx2-qt.psxRegs]
@@ -200,12 +200,12 @@ function setAddressesThroughPattern() {
     addresses["dynarecCheckBreakpoint"] = getFunctionAddress({
         name: "dynarecCheckBreakpoint",
         pattern: "8B 35 ???????? 8B 05 ???????? 48 39 05 ???????? 75 0D",
-        //       "8B 35 0BA18602 8B 05 1DA28602 48 39 05 8E5B530D 75 0D",
+        //       "8B 35 0BA18602 8B 05 1DA28602 48 39 05 8E5B530D 75 0D" v2.2.0
     });
     addresses["psxDynarecCheckBreakpoint"] = getFunctionAddress({
         name: "psxDynarecCheckBreakpoint",
         pattern: "8B 35 ???????? 8B 0D ???????? 31 FF B8 00000000",
-        //       "8B 35 6B178802 8B 0D 6D178802 31 FF B8 00000000",
+        //       "8B 35 6B178802 8B 0D 6D178802 31 FF B8 00000000" v2.2.0
     });
 }
 
@@ -214,12 +214,12 @@ if (
     FORCE_PATTERN_FALLBACK === false
 ) {
     console.warn("Using debug symbols");
-    setAddressesThroughDebug();
+    setupAddressesThroughDebug();
 } else {
     console.warn("Using pattern scanning");
 
     try {
-        setAddressesThroughPattern();
+        setupAddressesThroughPattern();
     } catch (err) {
         console.error(`
             \rFailed pattern scanning!

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -7,14 +7,14 @@ if (module.parent === null) {
     throw "I'm not a text hooker!";
 }
 
+const IS_DEBUG = false;
+const FORCE_PATTERN_FALLBACK = true;
+
 const __e = Process.mainModule;
 __e.size /= 2;
 
 const symbols = __e.enumerateSymbols();
 // console.log(JSON.stringify(Process.mainModule.enumerateSymbols(), null, 2));
-
-const IS_DEBUG = false;
-const FORCE_PATTERN_FALLBACK = false;
 
 //#region Find Addresses
 

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -66,8 +66,8 @@ function getPatternAddress({
 }
 
 /**
- * Scans a pattern in memory and returns a NativePointer
- * for the beginning of its function.
+ * Scans a pattern in memory and returns a NativePointer for the beginning
+ * of its function.
  * @param {Object} settings
  * @param {string} settings.name
  * @param {string} settings.pattern

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -1,13 +1,189 @@
 // @name         PCSX2 JIT Hooker
 // @version      2.2.0
-// @author       logantgt, based on work from [DC] and koukdw 
+// @author       logantgt, based on work from [DC] and koukdw
 // @description  windows, linux, mac (x64)
 
+const __e = Process.mainModule;
+__e.size /= 2;
+
+/**
+ * Scans a pattern in memory and returns a NativePointer for the last match.
+ * @param {Object} settings
+ * @param {string} settings.name
+ * @param {string} settings.pattern
+ * @param {NativePointer=} settings.base
+ * @param {number=} settings.size
+ * @returns {NativePointer}
+ */
+function getPatternAddress({
+    name,
+    pattern,
+    base = __e.base,
+    size = __e.size,
+}) {
+    /** @type {MemoryScanMatch[]} */
+    let results = null;
+
+    try {
+        results = Memory.scanSync(base, size, pattern);
+    } catch (err) {
+        throw new Error(`Error ocurred with [${name}]: ${err.message}`, {
+            cause: err,
+        });
+    }
+
+    if (results.length === 0) {
+        throw new Error(`[${name}] not found!`);
+    } else if (results.length > 1) {
+        console.warn(`${name} has ${results.length} results`);
+    }
+
+    const address = results.at(-1).address;
+
+    console.log(`\x1b[32m[${name}] @ ${address}\x1b[0m`);
+
+    return address;
+}
+
+/**
+ * Scans a pattern in memory and returns a NativePointer
+ * for the beginning of its function.
+ * @param {Object} settings
+ * @param {string} settings.name
+ * @param {string} settings.pattern
+ * @param {number=} settings.lookbackSize
+ * @returns {NativePointer}
+ */
+function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
+    const patternAddress = getPatternAddress({ name, pattern });
+    const settings = {
+        name: `${name}Prologue`,
+        pattern: "",
+        base: patternAddress.sub(lookbackSize),
+        size: lookbackSize,
+    };
+    let functionAddress = null;
+
+    try {
+        settings.pattern = "CC CC 4?";
+        functionAddress = getPatternAddress(settings);
+    } catch (err) {
+        settings.pattern = "CC CC 5?";
+        functionAddress = getPatternAddress(settings);
+    }
+
+    return functionAddress.add(2);
+}
+
+// console.log(JSON.stringify(Process.mainModule.enumerateSymbols(), null, 2));
+
+const BaseBlocks$New = getFunctionAddress({
+    name: "BaseBlocks$New",
+    // "4C 8B 40 08 41 80 78 19 00 0F84 76010000",
+    pattern: "4C 8B 40 08 41 80 78 19 00 0F84 ????0000",
+});
+const recRecompile = getFunctionAddress({
+    name: "recCompile",
+    // "48 8B 05 DB0B8303 48 3B 05 DC0B8303 72 07 C6 05 F30B8B03 01",
+    pattern: "48 8B 05 ???????? 48 3B 05 ???????? 72 07",
+});
+const iopRecRecompile = getFunctionAddress({
+    name: "iopRecRecompile",
+    // "81 F9 30160000 0F 84 8A000000 81 FE 90080000",
+    pattern: "81 F9 30160000 0F 84 8A000000 81 FE 90080000",
+});
+const recAddBreakpoint = getFunctionAddress({
+    name: "recAddBreakpoint",
+    pattern:
+        // "48 8B 3D 8055460D 4C 8B 1D 7155460D 48 89 F8 4C 29 D8 0F84 A5000000",
+        "48 8B 3D ???????? 4? 8B ?? ???????? 4? 89 F8 4? 29 ?? 0F84",
+});
+
+// R5900DebugInterface::setRegister
+const cpuRegsLoad = getPatternAddress({
+    name: "cpuRegsLoad",
+    // pattern: "48 8D 15 4F607A02 89 84 8A F0030000",
+    pattern: "48 8D 15 ???????? 89 84 8A F0030000",
+});
+let ins = Instruction.parse(cpuRegsLoad); // lea rdx,[pcsx2-qt._cpuRegistersPack]
+if (ins.mnemonic !== "lea") {
+    throw "Not lea";
+}
+let memOffset = ins.operands[1].value.disp;
+const cpuRegsPtr = ins.next.add(memOffset);
+
+// R3000DebugInterface::setRegister
+const psxRegsLoad = getPatternAddress({
+    name: "psxRegsLoad",
+    // pattern: "48 8D 15 3E4C7A02 89 04 8A C3",
+    pattern: "4? ?? ?? 48 8D 15 ???????? 89 04 8A C3",
+});
+ins = Instruction.parse(psxRegsLoad); // movsxd  rcx,r8d
+ins = Instruction.parse(ins.next); // lea rdx,[pcsx2-qt.psxRegs]
+if (ins.mnemonic !== "lea") {
+    throw "Not lea";
+}
+memOffset = ins.operands[1].value.disp;
+const psxRegsPtr = ins.next.add(memOffset);
+
+const dynarecCheckBreakpoint = getFunctionAddress({
+    name: "dynarecCheckBreakpoint",
+    // pattern: "8B 35 0BA18602 8B 05 1DA28602 48 39 05 8E5B530D 75 0D",
+    pattern: "8B 35 ???????? 8B 05 ???????? 48 39 05 ???????? 75 0D",
+});
+
+const psxDynarecCheckBreakpoint = getFunctionAddress({
+    name: "psxDynarecCheckBreakpoint",
+    // pattern: "8B 35 6B178802 8B 0D 6D178802 31 FF B8 00000000",
+    pattern: "8B 35 ???????? 8B 0D ???????? 31 FF B8 00000000",
+});
+
+const symbols = __e.enumerateSymbols();
+
+const eeMem = symbols.find((x) => x.name === "EEmem").address.readPointer();
+const iopMem = symbols.find((x) => x.name === "IOPmem").address.readPointer();
+
+// const addresses = {}
+
 // ?New@BaseBlocks@@QEAAPEAUBASEBLOCKEX@@I_K@Z
-const BaseBlocks$New = DebugSymbol.findFunctionsNamed('BaseBlocks::New')[0];
-const recRecompile = DebugSymbol.findFunctionsNamed('recRecompile')[0];
-const iopRecRecompile = DebugSymbol.findFunctionsNamed('iopRecRecompile')[0];
-const recAddBreakpoint = DebugSymbol.findFunctionsNamed('CBreakPoints::AddBreakPoint')[0];
+// const BaseBlocks$New = DebugSymbol.findFunctionsNamed("BaseBlocks::New")[0];
+// const recRecompile = DebugSymbol.findFunctionsNamed("recRecompile")[0];
+// const iopRecRecompile = DebugSymbol.findFunctionsNamed("iopRecRecompile")[0];
+// const recAddBreakpoint = DebugSymbol.findFunctionsNamed(
+//   "CBreakPoints::AddBreakPoint"
+// )[0];
+
+// const cpuRegsPtr = symbols.find((x) => x.name === "_cpuRegistersPack").address;
+// const eeMem = symbols.find((x) => x.name === "eeMem").address.readPointer();
+// const psxRegsPtr = symbols.find((x) => x.name === "psxRegs").address;
+// const iopMem = symbols.find((x) => x.name === "iopMem").address.readPointer();
+
+// const dynarecCheckBreakpoint = symbols.find(
+//   (x) => x.name === "dynarecCheckBreakpoint"
+// ).address;
+// const psxDynarecCheckBreakpoint = symbols.find(
+//   (x) => x.name === "psxDynarecCheckBreakpoint"
+// ).address;
+
+// const special = {
+//   BaseBlocks$New: BaseBlocks$New,
+//   recRecompile: recRecompile,
+//   iopRecRecompile: iopRecRecompile,
+//   recAddBreakpoint: recAddBreakpoint,
+//   cpuRegsPtr: cpuRegsPtr,
+//   eeMem: eeMem,
+//   psxRegsPtr: psxRegsPtr,
+//   iopMem: iopMem,
+// };
+// for (const [key, value] of Object.entries(special)) {
+//   console.warn(key, value.toString());
+// }
+
+// if (!BaseBlocks$New || !recRecompile || !iopRecRecompile || !recAddBreakpoint) {
+//     throw new Error("Missing debug symbols");
+// }
+
+// #region Everything Else
 
 const operations = Object.create(null);
 
@@ -29,24 +205,23 @@ Interceptor.attach(recRecompile, {
 
         const op = operations[startpc];
         if (op !== undefined) {
-            console.log('Attach EE:', ptr(startpc));
+            console.log("Attach EE:", ptr(startpc));
             jitAttachEE(startpc, recPtr, op);
         }
 
         // console.log('recRecompile: 0x' + startpc.toString(16) + ' -> ' + recPtr);
-    }
+    },
 });
 
-function jitAttachEE(startpc, recPtr, op)
-{
+function jitAttachEE(startpc, recPtr, op) {
     const thiz = Object.create(null, {});
     thiz.context = eeContext;
 
     Breakpoint.add(recPtr, () => {
         op.call(thiz, op[0]);
-        sessionStorage.setItem('PCSX2_EE_' + Date.now(), {
+        sessionStorage.setItem("PCSX2_EE_" + Date.now(), {
             guest: startpc,
-            host: recPtr
+            host: recPtr,
         });
     });
 }
@@ -61,265 +236,277 @@ Interceptor.attach(iopRecRecompile, {
 
         const op = operations[startpc];
         if (op !== undefined) {
-            console.log('Attach IOP:', ptr(startpc));
+            console.log("Attach IOP:", ptr(startpc));
             jitAttachIOP(startpc, recPtr, op);
         }
         // console.log('iopRecRecompile: 0x' + startpc.toString(16) + ' -> ' + recPtr);
-    }
+    },
 });
 
-function jitAttachIOP(startpc, recPtr, op)
-{
+function jitAttachIOP(startpc, recPtr, op) {
     const thiz = Object.create(null, {});
     thiz.context = iopContext;
 
     Breakpoint.add(recPtr, () => {
         op.call(thiz, op[0]);
-        sessionStorage.setItem('PCSX2_IOP_' + Date.now(), {
+        sessionStorage.setItem("PCSX2_IOP_" + Date.now(), {
             guest: startpc,
-            host: recPtr
+            host: recPtr,
         });
     });
 }
-
-const symbols = Process.mainModule.enumerateSymbols();
-
-const cpuRegsPtr = symbols.find(x => x.name === '_cpuRegistersPack').address;
-const eeMem = symbols.find(x => x.name === 'eeMem').address.readPointer();
-const psxRegsPtr = symbols.find(x => x.name === 'psxRegs').address;
-const iopMem = symbols.find(x => x.name ===  'iopMem').address.readPointer();
 
 // regs functions take a Typed Array View and run the constructor
 // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Typed_arrays)
 const eeContext = {
     mem: eeMem,
-    r0: function(view) {
-        return new view(cpuRegsPtr.readByteArray(16))
+    r0: function (view) {
+        return new view(cpuRegsPtr.readByteArray(16));
     },
-    at: function(view) {
-        return new view(cpuRegsPtr.add(16).readByteArray(16))
+    at: function (view) {
+        return new view(cpuRegsPtr.add(16).readByteArray(16));
     },
-    v0: function(view) {
-        return new view(cpuRegsPtr.add(32).readByteArray(16))
+    v0: function (view) {
+        return new view(cpuRegsPtr.add(32).readByteArray(16));
     },
-    v1: function(view) {
-        return new view(cpuRegsPtr.add(48).readByteArray(16))
+    v1: function (view) {
+        return new view(cpuRegsPtr.add(48).readByteArray(16));
     },
-    a0: function(view) {
-        return new view(cpuRegsPtr.add(64).readByteArray(16))
+    a0: function (view) {
+        return new view(cpuRegsPtr.add(64).readByteArray(16));
     },
-    a1: function(view) {
-        return new view(cpuRegsPtr.add(80).readByteArray(16))
+    a1: function (view) {
+        return new view(cpuRegsPtr.add(80).readByteArray(16));
     },
-    a2: function(view) {
-        return new view(cpuRegsPtr.add(96).readByteArray(16))
+    a2: function (view) {
+        return new view(cpuRegsPtr.add(96).readByteArray(16));
     },
-    a3: function(view) {
-        return new view(cpuRegsPtr.add(112).readByteArray(16))
+    a3: function (view) {
+        return new view(cpuRegsPtr.add(112).readByteArray(16));
     },
-    t0: function(view) {
-        return new view(cpuRegsPtr.add(128).readByteArray(16))
+    t0: function (view) {
+        return new view(cpuRegsPtr.add(128).readByteArray(16));
     },
-    t1: function(view) {
-        return new view(cpuRegsPtr.add(144).readByteArray(16))
+    t1: function (view) {
+        return new view(cpuRegsPtr.add(144).readByteArray(16));
     },
-    t2: function(view) {
-        return new view(cpuRegsPtr.add(160).readByteArray(16))
+    t2: function (view) {
+        return new view(cpuRegsPtr.add(160).readByteArray(16));
     },
-    t3: function(view) {
-        return new view(cpuRegsPtr.add(176).readByteArray(16))
+    t3: function (view) {
+        return new view(cpuRegsPtr.add(176).readByteArray(16));
     },
-    t4: function(view) {
-        return new view(cpuRegsPtr.add(192).readByteArray(16))
+    t4: function (view) {
+        return new view(cpuRegsPtr.add(192).readByteArray(16));
     },
-    t5: function(view) {
-        return new view(cpuRegsPtr.add(208).readByteArray(16))
+    t5: function (view) {
+        return new view(cpuRegsPtr.add(208).readByteArray(16));
     },
-    t6: function(view) {
-        return new view(cpuRegsPtr.add(224).readByteArray(16))
+    t6: function (view) {
+        return new view(cpuRegsPtr.add(224).readByteArray(16));
     },
-    t7: function(view) {
-        return new view(cpuRegsPtr.add(240).readByteArray(16))
+    t7: function (view) {
+        return new view(cpuRegsPtr.add(240).readByteArray(16));
     },
-    s0: function(view) {
-        return new view(cpuRegsPtr.add(256).readByteArray(16))
+    s0: function (view) {
+        return new view(cpuRegsPtr.add(256).readByteArray(16));
     },
-    s1: function(view) {
-        return new view(cpuRegsPtr.add(272).readByteArray(16))
+    s1: function (view) {
+        return new view(cpuRegsPtr.add(272).readByteArray(16));
     },
-    s2: function(view) {
-        return new view(cpuRegsPtr.add(288).readByteArray(16))
+    s2: function (view) {
+        return new view(cpuRegsPtr.add(288).readByteArray(16));
     },
-    s3: function(view) {
-        return new view(cpuRegsPtr.add(304).readByteArray(16))
+    s3: function (view) {
+        return new view(cpuRegsPtr.add(304).readByteArray(16));
     },
-    s4: function(view) {
-        return new view(cpuRegsPtr.add(320).readByteArray(16))
+    s4: function (view) {
+        return new view(cpuRegsPtr.add(320).readByteArray(16));
     },
-    s5: function(view) {
-        return new view(cpuRegsPtr.add(336).readByteArray(16))
+    s5: function (view) {
+        return new view(cpuRegsPtr.add(336).readByteArray(16));
     },
-    s6: function(view) {
-        return new view(cpuRegsPtr.add(352).readByteArray(16))
+    s6: function (view) {
+        return new view(cpuRegsPtr.add(352).readByteArray(16));
     },
-    s7: function(view) {
-        return new view(cpuRegsPtr.add(368).readByteArray(16))
+    s7: function (view) {
+        return new view(cpuRegsPtr.add(368).readByteArray(16));
     },
-    t8: function(view) {
-        return new view(cpuRegsPtr.add(384).readByteArray(16))
+    t8: function (view) {
+        return new view(cpuRegsPtr.add(384).readByteArray(16));
     },
-    t9: function(view) {
-        return new view(cpuRegsPtr.add(400).readByteArray(16))
+    t9: function (view) {
+        return new view(cpuRegsPtr.add(400).readByteArray(16));
     },
-    k0: function(view) {
-        return new view(cpuRegsPtr.add(416).readByteArray(16))
+    k0: function (view) {
+        return new view(cpuRegsPtr.add(416).readByteArray(16));
     },
-    k1: function(view) {
-        return new view(cpuRegsPtr.add(432).readByteArray(16))
+    k1: function (view) {
+        return new view(cpuRegsPtr.add(432).readByteArray(16));
     },
-    gp: function(view) {
-        return new view(cpuRegsPtr.add(448).readByteArray(16))
+    gp: function (view) {
+        return new view(cpuRegsPtr.add(448).readByteArray(16));
     },
-    sp: function(view) {
-        return new view(cpuRegsPtr.add(464).readByteArray(16))
+    sp: function (view) {
+        return new view(cpuRegsPtr.add(464).readByteArray(16));
     },
-    s8: function(view) {
-        return new view(cpuRegsPtr.add(480).readByteArray(16))
+    s8: function (view) {
+        return new view(cpuRegsPtr.add(480).readByteArray(16));
     },
-    ra: function(view) {
-        return new view(cpuRegsPtr.add(496).readByteArray(16))
-    }
-}
+    ra: function (view) {
+        return new view(cpuRegsPtr.add(496).readByteArray(16));
+    },
+};
 
 const iopContext = {
     mem: iopMem,
-    r0: function(view) {
-        return new view(psxRegsPtr.readByteArray(4))
+    r0: function (view) {
+        return new view(psxRegsPtr.readByteArray(4));
     },
-    at: function(view) {
-        return new view(psxRegsPtr.add(4).readByteArray(4))
+    at: function (view) {
+        return new view(psxRegsPtr.add(4).readByteArray(4));
     },
-    v0: function(view) {
-        return new view(psxRegsPtr.add(8).readByteArray(4))
+    v0: function (view) {
+        return new view(psxRegsPtr.add(8).readByteArray(4));
     },
-    v1: function(view) {
-        return new view(psxRegsPtr.add(12).readByteArray(4))
+    v1: function (view) {
+        return new view(psxRegsPtr.add(12).readByteArray(4));
     },
-    a0: function(view) {
-        return new view(psxRegsPtr.add(16).readByteArray(4))
+    a0: function (view) {
+        return new view(psxRegsPtr.add(16).readByteArray(4));
     },
-    a1: function(view) {
-        return new view(psxRegsPtr.add(20).readByteArray(4))
+    a1: function (view) {
+        return new view(psxRegsPtr.add(20).readByteArray(4));
     },
-    a2: function(view) {
-        return new view(psxRegsPtr.add(24).readByteArray(4))
+    a2: function (view) {
+        return new view(psxRegsPtr.add(24).readByteArray(4));
     },
-    a3: function(view) {
-        return new view(psxRegsPtr.add(28).readByteArray(4))
+    a3: function (view) {
+        return new view(psxRegsPtr.add(28).readByteArray(4));
     },
-    t0: function(view) {
-        return new view(psxRegsPtr.add(32).readByteArray(4))
+    t0: function (view) {
+        return new view(psxRegsPtr.add(32).readByteArray(4));
     },
-    t1: function(view) {
-        return new view(psxRegsPtr.add(36).readByteArray(4))
+    t1: function (view) {
+        return new view(psxRegsPtr.add(36).readByteArray(4));
     },
-    t2: function(view) {
-        return new view(psxRegsPtr.add(40).readByteArray(4))
+    t2: function (view) {
+        return new view(psxRegsPtr.add(40).readByteArray(4));
     },
-    t3: function(view) {
-        return new view(psxRegsPtr.add(44).readByteArray(4))
+    t3: function (view) {
+        return new view(psxRegsPtr.add(44).readByteArray(4));
     },
-    t4: function(view) {
-        return new view(psxRegsPtr.add(48).readByteArray(4))
+    t4: function (view) {
+        return new view(psxRegsPtr.add(48).readByteArray(4));
     },
-    t5: function(view) {
-        return new view(psxRegsPtr.add(52).readByteArray(4))
+    t5: function (view) {
+        return new view(psxRegsPtr.add(52).readByteArray(4));
     },
-    t6: function(view) {
-        return new view(psxRegsPtr.add(56).readByteArray(4))
+    t6: function (view) {
+        return new view(psxRegsPtr.add(56).readByteArray(4));
     },
-    t7: function(view) {
-        return new view(psxRegsPtr.add(60).readByteArray(4))
+    t7: function (view) {
+        return new view(psxRegsPtr.add(60).readByteArray(4));
     },
-    s0: function(view) {
-        return new view(psxRegsPtr.add(64).readByteArray(4))
+    s0: function (view) {
+        return new view(psxRegsPtr.add(64).readByteArray(4));
     },
-    s1: function(view) {
-        return new view(psxRegsPtr.add(68).readByteArray(4))
+    s1: function (view) {
+        return new view(psxRegsPtr.add(68).readByteArray(4));
     },
-    s2: function(view) {
-        return new view(psxRegsPtr.add(72).readByteArray(4))
+    s2: function (view) {
+        return new view(psxRegsPtr.add(72).readByteArray(4));
     },
-    s3: function(view) {
-        return new view(psxRegsPtr.add(76).readByteArray(4))
+    s3: function (view) {
+        return new view(psxRegsPtr.add(76).readByteArray(4));
     },
-    s4: function(view) {
-        return new view(psxRegsPtr.add(80).readByteArray(4))
+    s4: function (view) {
+        return new view(psxRegsPtr.add(80).readByteArray(4));
     },
-    s5: function(view) {
-        return new view(psxRegsPtr.add(84).readByteArray(4))
+    s5: function (view) {
+        return new view(psxRegsPtr.add(84).readByteArray(4));
     },
-    s6: function(view) {
-        return new view(psxRegsPtr.add(88).readByteArray(4))
+    s6: function (view) {
+        return new view(psxRegsPtr.add(88).readByteArray(4));
     },
-    s7: function(view) {
-        return new view(psxRegsPtr.add(92).readByteArray(4))
+    s7: function (view) {
+        return new view(psxRegsPtr.add(92).readByteArray(4));
     },
-    t8: function(view) {
-        return new view(psxRegsPtr.add(96).readByteArray(4))
+    t8: function (view) {
+        return new view(psxRegsPtr.add(96).readByteArray(4));
     },
-    t9: function(view) {
-        return new view(psxRegsPtr.add(100).readByteArray(4))
+    t9: function (view) {
+        return new view(psxRegsPtr.add(100).readByteArray(4));
     },
-    k0: function(view) {
-        return new view(psxRegsPtr.add(104).readByteArray(4))
+    k0: function (view) {
+        return new view(psxRegsPtr.add(104).readByteArray(4));
     },
-    k1: function(view) {
-        return new view(psxRegsPtr.add(108).readByteArray(4))
+    k1: function (view) {
+        return new view(psxRegsPtr.add(108).readByteArray(4));
     },
-    gp: function(view) {
-        return new view(psxRegsPtr.add(112).readByteArray(4))
+    gp: function (view) {
+        return new view(psxRegsPtr.add(112).readByteArray(4));
     },
-    sp: function(view) {
-        return new view(psxRegsPtr.add(116).readByteArray(4))
+    sp: function (view) {
+        return new view(psxRegsPtr.add(116).readByteArray(4));
     },
-    s8: function(view) {
-        return new view(psxRegsPtr.add(120).readByteArray(4))
+    s8: function (view) {
+        return new view(psxRegsPtr.add(120).readByteArray(4));
     },
-    ra: function(view) {
-        return new view(psxRegsPtr.add(124).readByteArray(4))
-    }
-}
+    ra: function (view) {
+        return new view(psxRegsPtr.add(124).readByteArray(4));
+    },
+};
 
 // replace dynarecCheckBreakpoint (for EE)
 // This results in the same outcome as creating a breakpoint with an unsatisfiable condition in the UI (like 1 < 0)
-const dynarecCheckBreakpoint = symbols.find(x => x.name === 'dynarecCheckBreakpoint');
-Interceptor.replace(dynarecCheckBreakpoint.address, new NativeCallback(() => { return; }, 'void', []));
+Interceptor.replace(
+    dynarecCheckBreakpoint,
+    new NativeCallback(
+        () => {
+            return;
+        },
+        "void",
+        []
+    )
+);
 
 // replace psxDynarecCheckBreakpoint (for IOP)
-const psxDynarecCheckBreakpoint = symbols.find(x => x.name === 'psxDynarecCheckBreakpoint');
-Interceptor.replace(psxDynarecCheckBreakpoint.address, new NativeCallback(() => { return; }, 'void', []));
+Interceptor.replace(
+    psxDynarecCheckBreakpoint,
+    new NativeCallback(
+        () => {
+            return;
+        },
+        "void",
+        []
+    )
+);
 
 async function setHookEE(object) {
     for (const key in object) {
         if (Object.hasOwnProperty.call(object, key)) {
             const element = object[key];
             operations[key] = element;
-            var addBp = new NativeFunction(recAddBreakpoint, 'void', ['uint8', 'uint32', 'bool', 'bool']);
+            var addBp = new NativeFunction(recAddBreakpoint, "void", [
+                "uint8",
+                "uint32",
+                "bool",
+                "bool",
+            ]);
             addBp(0x01, parseInt(key), 0x00, 0x01);
         }
     }
 
-    Object.keys(sessionStorage).map(key => {
+    Object.keys(sessionStorage).map((key) => {
         const value = sessionStorage.getItem(key);
-        if (key.startsWith('PCSX2_EE_') === true) {
+        if (key.startsWith("PCSX2_EE_") === true) {
             try {
                 const startpc = value.guest;
                 const recPtr = ptr(value.host);
                 const op = operations[startpc.toString()];
                 jitAttachEE(startpc, recPtr, op);
-            }
-            catch (e) {
+            } catch (e) {
                 console.error(e);
             }
         }
@@ -331,34 +518,39 @@ async function setHookIOP(object) {
         if (Object.hasOwnProperty.call(object, key)) {
             const element = object[key];
             operations[key] = element;
-            var addBp = new NativeFunction(recAddBreakpoint, 'void', ['uint8', 'uint32', 'bool', 'bool']);
+            var addBp = new NativeFunction(recAddBreakpoint, "void", [
+                "uint8",
+                "uint32",
+                "bool",
+                "bool",
+            ]);
             addBp(0x02, parseInt(key), 0x00, 0x01);
         }
     }
 
-    Object.keys(sessionStorage).map(key => {
+    Object.keys(sessionStorage).map((key) => {
         const value = sessionStorage.getItem(key);
-        if (key.startsWith('PCSX2_IOP_') === true) {
+        if (key.startsWith("PCSX2_IOP_") === true) {
             try {
                 const startpc = value.guest;
                 const recPtr = ptr(value.host);
                 const op = operations[startpc.toString()];
                 jitAttachIOP(startpc, recPtr, op);
-            }
-            catch (e) {
+            } catch (e) {
                 console.error(e);
             }
         }
     });
 }
 
-function asPsxPtr(bytes)
-{
+function asPsxPtr(bytes) {
     return eeContext.mem.add(ptr(new Uint32Array(bytes)[0]));
 }
 
 module.exports = exports = {
     setHookEE,
     setHookIOP,
-    asPsxPtr
-}
+    asPsxPtr,
+};
+
+// #endregion

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -82,6 +82,7 @@ function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
         for (let i = candidates.length - 1; i >= 0; i--) {
             const address = candidates[i].address.add(1);
             const ins = Instruction.parse(address);
+
             if (ins.mnemonic === "push") {
                 return address;
             }
@@ -98,6 +99,7 @@ function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
     for (const pattern of patterns) {
         const results = Memory.scanSync(base, size, pattern);
         const startAddress = findFunctionStartAddress(results);
+
         if (startAddress !== null) {
             if (IS_DEBUG) console.log(`[${name}Prologue] @ ${address}`);
 
@@ -215,6 +217,7 @@ if (
     findAddressesThroughDebug();
 } else {
     console.warn("Using pattern scanning");
+
     try {
         findAddressesThroughPattern();
     } catch (err) {
@@ -223,6 +226,7 @@ if (
             \rInstall debug symbols to make PCSX2 hooking work,
             \ror wait for someone to fix the patterns.
         `);
+
         throw err;
     }
 }

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -77,14 +77,14 @@ function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
     const base = patternAddress.sub(lookbackSize);
     const size = lookbackSize;
 
-    /** @param {MemoryScanMatch[]} results */
-    function findFunctionStartAddress(results) {
-        if (results === 0) {
+    /** @param {MemoryScanMatch[]} candidates */
+    function findFunctionStartAddress(candidates) {
+        if (candidates === 0) {
             return null;
         }
 
-        for (let i = results.length - 1; i >= 0; i--) {
-            const address = results[i].address.add(1);
+        for (let i = candidates.length - 1; i >= 0; i--) {
+            const address = candidates[i].address.add(1);
             const ins = Instruction.parse(address);
             if (ins.mnemonic === "push") {
                 return address;
@@ -95,15 +95,15 @@ function getFunctionAddress({ name, pattern, lookbackSize = 0x100 }) {
     }
 
     {
-        const candidates = Memory.scanSync(base, size, "CC 4?");
-        const address = findFunctionStartAddress(candidates);
+        const results = Memory.scanSync(base, size, "CC 4?");
+        const address = findFunctionStartAddress(results);
         if (address !== null) {
             return address;
         }
     }
     {
-        const candidates = Memory.scanSync(base, size, "CC 5?");
-        const address = findFunctionStartAddress(candidates);
+        const results = Memory.scanSync(base, size, "CC 5?");
+        const address = findFunctionStartAddress(results);
         if (address !== null) {
             return address;
         }


### PR DESCRIPTION
Tested on v2.2.0, v2.3.254, and v2.3.257.
First tries to use debug symbols, and if they're missing, looks for the functions through pattern scanning instead.