### PR TITLE
Cache libPCSX2 addresses and improve scan accuracy

### DIFF
--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -25,7 +25,7 @@ const addresses = Object.create(null);
 
 // enumerateSymbols() is a slow operation,
 // postpone it until we're sure there are no cached addresses in sessionStorage
-/** @type {ModuleSymbolDetails[]} */
+/** @type {ModuleSymbolDetails[]|null} */
 let symbols = null;
 
 const __ranges = Process.enumerateRanges("r-x");

--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -162,7 +162,7 @@ function calculateLeaAddress(ins) {
 }
 
 function setupAddressesThroughCache() {
-    /** @type {Object.<string, NativePointer>} */
+    /** @type {Object.<string, NativePointer>|null} */
     const cachedAddresses = sessionStorage.getItem("PCSX2_ADDRESSES");
 
     if (cachedAddresses === null) {


### PR DESCRIPTION
- Previously, access violation errors were avoided by naively halving the module size for scanning. Changed it so that the scan only goes through readable regions in the first place.
- Setup addresses are now cached to speedup subsequent attaches from ~3 seconds down to a few milliseconds.