### PR TITLE
Add asRawPtr helper function for libPCSX2

### DIFF
--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -664,10 +664,15 @@ function asPsxPtr(bytes) {
     return eeContext.mem.add(ptr(new Uint32Array(bytes)[0]));
 }
 
+function asRawPtr(bytes) {
+    return ptr(new Uint32Array(bytes)[0]);
+}
+
 module.exports = exports = {
     setHookEE,
     setHookIOP,
     asPsxPtr,
+    asRawPtr,
 };
 
 // #endregion


### PR DESCRIPTION
For situations in which you only need the emulation address like for Akai Ito. This could probably be named better.