### PR TITLE
Add Octopath Traveler 0

### DIFF
--- a/PC_Steam_Unreal_OCTOPATH_TRAVELER_0.js
+++ b/PC_Steam_Unreal_OCTOPATH_TRAVELER_0.js
@@ -1,10 +1,10 @@
 // ==UserScript==
 // @name         OCTOPATH TRAVELER 0
-// @developer    Square Enix / DOKIDOKI GROOVE WORKS
-// @version      0.1
+// @version      1.0.3.0
 // @author       Mansive / Musi
 // @description  Steam
-// * KEY
+// * Square Enix
+// * DOKIDOKI GROOVE WORKS
 //
 // https://store.steampowered.com/app/3014320/OCTOPATH_TRAVELER_0/
 // ==/UserScript==


### PR DESCRIPTION
This adds a script for Octopath Traveler 0, I couldn't find any good hooks for menus, choices and tutorials but it should still cover 80%-90% of the games text. Also thanks to @Mansive for helping out with it.