### PR TITLE
Update libPCSX2 with Android support

### DIFF
--- a/libPCSX2.js
+++ b/libPCSX2.js
@@ -19,7 +19,7 @@ const __e =
 
 console.warn("[Compatibility]");
 console.warn("PCSX2 2.2.0 -> 2.6.2");
-console.warn("ARMSX2 1.0.7");
+console.warn("ARMSX2 1.0.8+");
 console.log("[Mirror] Download: https://github.com/koukdw/emulators/releases");
 
 // #region Find Addresses


### PR DESCRIPTION
Only supports ARMSX2 builds with debug symbols and root access for now. Besides Android support, the biggest change is reading the pointers from `eeMem` and `iopMem` whenever a hook triggers instead of at setup. Those two are initialized with nulls on Android until a game starts, different from Windows and Linux where they're initialized with proper pointers upon emulator launch.

Builds with debug symbols: https://github.com/Mansive/ARMSX2/releases