### PR TITLE
Improve sentence handling in The House in Fata Morgana

### DIFF
--- a/PC_Steam_The_House_in_Fata_Morgana.js
+++ b/PC_Steam_The_House_in_Fata_Morgana.js
@@ -30,7 +30,7 @@ console.warn('[Known Issue] Some inner dialogue is picked up even when not displ
     
     function endsWithPunctuation(text) {
         // check if text ends with punctuation
-        return /[。！？…・]$/.test(text);
+        return /[。！？…・）]$/.test(text);
     }
     
     function hasJapaneseText(text) {


### PR DESCRIPTION
Updates the ```endsWithPunctuation``` function to include brackets, which are used to represent inner thoughts. These brackets appear later in the game than the point at which the script was originally tested. As a result, any text in brackets was being output once a spoken sentence ended with the other punctuation symbols. Apologies for not catching this earlier.